### PR TITLE
HTTPS config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 
 #ENV
 .env*
+
+# Certificate
+/cert

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,9 @@ services:
       - strapi
       - mongodb
       - frontend
+    environment:
+      STRAPI_ADMIN_EMAIL: ${STRAPI_ADMIN_EMAIL}
+      PROXY_DOMAIN: ${PROXY_DOMAIN}
   frontend:
     restart: unless-stopped
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,8 @@ services:
     environment:
       STRAPI_ADMIN_EMAIL: ${STRAPI_ADMIN_EMAIL}
       PROXY_DOMAIN: ${PROXY_DOMAIN}
+    volumes:
+      - './cert:/etc/letsencrypt'
   frontend:
     restart: unless-stopped
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - strapi
       - mongodb
+      - frontend
   frontend:
     restart: unless-stopped
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - '80:80'
+      - '443:443'
     depends_on:
       - strapi
       - mongodb

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 FROM base as nginx
 COPY default.conf /etc/nginx/conf.d/
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-RUN "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos"
-RUN "cron"
+RUN certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos
+RUN cron
 CMD ["sh", "-c", "nginx -g \"daemon off;\""]
 EXPOSE 80 443

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,5 +5,7 @@ RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 FROM base as nginx
 COPY default.conf /etc/nginx/conf.d/
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+RUN "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos"
+RUN "cron"
+CMD ["sh", "-c", "nginx -g \"daemon off;\""]
 EXPOSE 80 443

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 
 FROM base as nginx
 COPY default.conf /etc/nginx/conf.d/
-RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
 EXPOSE 80 443
+# RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
+RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
+CMD ["sh", "-c", "certbot --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+
+# CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -9,4 +9,4 @@ ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --nginx -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,7 +5,5 @@ RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 FROM base as nginx
 COPY default.conf /etc/nginx/conf.d/
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-RUN certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos
-RUN cron
-CMD ["sh", "-c", "nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
 EXPOSE 80 443

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -9,4 +9,4 @@ ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -9,4 +9,4 @@ ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --nginx -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,9 @@
-FROM nginx:alpine as nginx
-COPY nginx.conf /etc/nginx/nginx.conf
-ENTRYPOINT ["nginx","-g","daemon off;"]
-EXPOSE 80
+# COPY nginx.conf /etc/nginx/nginx.conf
+FROM nginx:1.23.3 as base
+RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
+
+FROM base as nginx
+COPY default.conf /etc/nginx/conf.d/
+RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
+CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+EXPOSE 80 443

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,20 +7,4 @@ ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-
-# CMD ["sh", "-c",
-# "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then
-#         certbot certonly --standalone \
-#             -d $PROXY_DOMAIN \
-#             -d webmaster.cpe.kmutt.ac.th \
-#             --email $STRAPI_ADMIN_EMAIL \
-#             --noninteractive \
-#             --agree-tos;
-#     fi &&
-#     cron &&
-#     nginx -g \"daemon off;\""
-# ]
-
-CMD ["sh", "-c", "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos; fi && cron && nginx -g \"daemon off;\""]
-
-# CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then certbot certonly --standalone -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos; fi && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -2,9 +2,7 @@ FROM nginx:1.23.3 as base
 RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 
 FROM base as nginx
-ARG STRAPI_ADMIN_EMAIL
 ENV STRAPI_ADMIN_EMAIL=${STRAPI_ADMIN_EMAIL}
-ARG PROXY_DOMAIN
 ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,12 +1,8 @@
-# COPY nginx.conf /etc/nginx/nginx.conf
 FROM nginx:1.23.3 as base
 RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 
 FROM base as nginx
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
-# RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
 CMD ["sh", "-c", "certbot certonly --standalone -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
-
-# CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -2,7 +2,11 @@ FROM nginx:1.23.3 as base
 RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 
 FROM base as nginx
+ARG STRAPI_ADMIN_EMAIL
+ENV STRAPI_ADMIN_EMAIL=${STRAPI_ADMIN_EMAIL}
+ARG PROXY_DOMAIN
+ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --standalone -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,6 +7,6 @@ COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 # RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "certbot certonly --standalone -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
 
 # CMD ["sh", "-c", "certbot certonly --nginx -d cpe.kmutt.ac.th --email admin@cpe.kmutt.ac.th --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,19 +8,19 @@ COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
 
-CMD ["sh", "-c",
-"if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then 
-        certbot certonly --standalone \
-            -d $PROXY_DOMAIN \
-            -d webmaster.cpe.kmutt.ac.th \
-            --email $STRAPI_ADMIN_EMAIL \
-            --noninteractive \
-            --agree-tos; 
-    fi && 
-    cron && 
-    nginx -g \"daemon off;\""
-]
+# CMD ["sh", "-c",
+# "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then
+#         certbot certonly --standalone \
+#             -d $PROXY_DOMAIN \
+#             -d webmaster.cpe.kmutt.ac.th \
+#             --email $STRAPI_ADMIN_EMAIL \
+#             --noninteractive \
+#             --agree-tos;
+#     fi &&
+#     cron &&
+#     nginx -g \"daemon off;\""
+# ]
 
-# CMD ["sh", "-c", "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos; fi && cron && nginx -g \"daemon off;\""]
+CMD ["sh", "-c", "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos; fi && cron && nginx -g \"daemon off;\""]
 
 # CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,4 +7,20 @@ ENV PROXY_DOMAIN=${PROXY_DOMAIN}
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80 443
 RUN echo "0 0 1 * * certbot renew && docker kill -s HUP nginx-certbot" >>/etc/crontab
-CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]
+
+CMD ["sh", "-c",
+"if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then 
+        certbot certonly --standalone \
+            -d $PROXY_DOMAIN \
+            -d webmaster.cpe.kmutt.ac.th \
+            --email $STRAPI_ADMIN_EMAIL \
+            --noninteractive \
+            --agree-tos; 
+    fi && 
+    cron && 
+    nginx -g \"daemon off;\""
+]
+
+# CMD ["sh", "-c", "if [ ! -f /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem ]; then certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos; fi && cron && nginx -g \"daemon off;\""]
+
+# CMD ["sh", "-c", "certbot certonly --standalone -d $PROXY_DOMAIN -d webmaster.cpe.kmutt.ac.th --email $STRAPI_ADMIN_EMAIL --noninteractive --agree-tos && cron && nginx -g \"daemon off;\""]

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -3,9 +3,9 @@ upstream be {
 }
 
 upstream fe {
-    server cpe-kmutt-web-frontend-1:3000;
-    server cpe-kmutt-web-frontend-2:3000;
-    server cpe-kmutt-web-frontend-3:3000;
+    server cpe-kmutt-web_frontend_1:3000;
+    server cpe-kmutt-web_frontend_2:3000;
+    server cpe-kmutt-web_frontend_3:3000;
 }
 
 upstream strapi {

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -13,11 +13,17 @@ upstream strapi {
 }
 
 server {
-    server_name cpe.kmutt.ac.th;
+    set $default_value default;
+    set $domain $PROXY_DOMAIN;
+    if ($domain = "") {
+        set $doamin $default_value;
+    }
+
+    server_name $domain;
     listen 443 ssl;
 
-    ssl_certificate /etc/letsencrypt/live/cpe.kmutt.ac.th/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/cpe.kmutt.ac.th/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$domain/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
 
     location / {
         proxy_pass http://fe;
@@ -40,7 +46,13 @@ server {
 }
 
 server {
-    server_name cpe.kmutt.ac.th;
+    set $default_value default;
+    set $domain $PROXY_DOMAIN;
+    if ($domain = "") {
+        set $doamin $default_value;
+    }
+
+    server_name $domain;
     listen 80;
 
     location / {

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -13,17 +13,11 @@ upstream strapi {
 }
 
 server {
-    set $default_value default;
-    set $domain $PROXY_DOMAIN;
-    if ($domain = "") {
-        set $doamin $default_value;
-    }
-
-    server_name $domain;
+    server_name $PROXY_DOMAIN;
     listen 443 ssl;
 
-    ssl_certificate /etc/letsencrypt/live/$domain/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$PROXY_DOMAIN/privkey.pem;
 
     location / {
         proxy_pass http://fe;
@@ -46,13 +40,7 @@ server {
 }
 
 server {
-    set $default_value default;
-    set $domain $PROXY_DOMAIN;
-    if ($domain = "") {
-        set $doamin $default_value;
-    }
-
-    server_name $domain;
+    server_name $PROXY_DOMAIN;
     listen 80;
 
     location / {

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -29,19 +29,12 @@ server {
         access_log off;
     }
 
-    location /files {
+    location ~ /(admin|content-manager|i18n|content-type-builder|upload|uploads|files|file) {
         proxy_pass http://strapi;
-        access_log off;
-    }
-
-    location ^~ /strapi {
-        rewrite ^/strapi/(.*) /$1 break;
-        proxy_pass http://strapi;
-        access_log off;
-    }
-    location ^~ /uploads {
-        rewrite ^/uploads/(.*) /uploads/$1 break;
-        proxy_pass http://strapi;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         access_log off;
     }
 }

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -13,11 +13,11 @@ upstream strapi {
 }
 
 server {
-    server_name ${PROXY_DOMAIN};
+    server_name cpe.kmutt.ac.th;
     listen 443 ssl;
 
-    ssl_certificate /etc/letsencrypt/live/${PROXY_DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${PROXY_DOMAIN}/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/cpe.kmutt.ac.th/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cpe.kmutt.ac.th/privkey.pem;
 
     location / {
         proxy_pass http://fe;
@@ -40,7 +40,7 @@ server {
 }
 
 server {
-    server_name ${PROXY_DOMAIN};
+    server_name cpe.kmutt.ac.th;
     listen 80;
 
     location / {

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -14,7 +14,7 @@ upstream strapi {
 
 server {
     server_name cpe.kmutt.ac.th;
-    listen 443;
+    listen 443 ssl;
 
     ssl_certificate /etc/letsencrypt/live/cpe.kmutt.ac.th/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/cpe.kmutt.ac.th/privkey.pem;

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -1,0 +1,56 @@
+upstream be {
+    server cpe-kmutt-backend-prod:3000;
+}
+
+upstream fe {
+    server cpe-kmutt-web-frontend-1:3000;
+    server cpe-kmutt-web-frontend-2:3000;
+    server cpe-kmutt-web-frontend-3:3000;
+}
+
+upstream strapi {
+    server cpe-kmutt-strapi-prod:1337;
+}
+
+server {
+    server_name cpe.kmutt.ac.th;
+    listen 443;
+
+    ssl_certificate /etc/letsencrypt/live/cpe.kmutt.ac.th/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cpe.kmutt.ac.th/privkey.pem;
+
+    location / {
+        proxy_pass http://fe;
+        access_log off;
+    }
+
+    location /api {
+        proxy_pass http://be;
+        access_log off;
+    }
+
+    location /files {
+        proxy_pass http://strapi;
+        access_log off;
+    }
+
+    location ^~ /strapi {
+        rewrite ^/strapi/(.*) /$1 break;
+        proxy_pass http://strapi;
+        access_log off;
+    }
+    location ^~ /uploads {
+        rewrite ^/uploads/(.*) /uploads/$1 break;
+        proxy_pass http://strapi;
+        access_log off;
+    }
+}
+
+server {
+    server_name cpe.kmutt.ac.th;
+    listen 80;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -13,11 +13,11 @@ upstream strapi {
 }
 
 server {
-    server_name $PROXY_DOMAIN;
+    server_name ${PROXY_DOMAIN};
     listen 443 ssl;
 
-    ssl_certificate /etc/letsencrypt/live/$PROXY_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$PROXY_DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${PROXY_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${PROXY_DOMAIN}/privkey.pem;
 
     location / {
         proxy_pass http://fe;
@@ -40,7 +40,7 @@ server {
 }
 
 server {
-    server_name $PROXY_DOMAIN;
+    server_name ${PROXY_DOMAIN};
     listen 80;
 
     location / {

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -8,37 +8,37 @@ events {
 
 http {
     server_tokens off;
-    sendfile        on;
-    tcp_nopush      on;
-    tcp_nodelay     off;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay off;
     client_max_body_size 50M;
 
     gzip on;
-    gzip_http_version  1.0;
-    gzip_comp_level    5;
-    gzip_min_length    256;
-    gzip_proxied       any;
-    gzip_vary          on;
+    gzip_http_version 1.0;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
     gzip_types
-        application/atom+xml
-        application/javascript
-        application/json
-        application/rss+xml
-        application/vnd.ms-fontobject
-        application/x-font-ttf
-        application/x-web-app-manifest+json
-        application/xhtml+xml
-        application/xml
-        font/opentype
-        image/svg+xml
-        image/x-icon
-        text/css
-        text/plain
-        text/x-component;
-    
+    application/atom+xml
+    application/javascript
+    application/json
+    application/rss+xml
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/svg+xml
+    image/x-icon
+    text/css
+    text/plain
+    text/x-component;
 
-        include       /etc/nginx/mime.types;
-        default_type  application/octet-stream;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
     upstream be {
         server cpe-kmutt-backend-prod:3000;
@@ -56,33 +56,38 @@ http {
 
     server {
         server_name _;
-        listen 80;
+        listen 443;
 
         location / {
-            proxy_pass   http://fe;
+            proxy_pass http://fe;
             access_log off;
         }
 
         location /api {
-            proxy_pass   http://be;
+            proxy_pass http://be;
             access_log off;
         }
 
         location /files {
-            proxy_pass   http://strapi;
+            proxy_pass http://strapi;
             access_log off;
         }
 
         location ^~ /strapi {
-            rewrite           ^/strapi/(.*) /$1 break;
-            proxy_pass   http://strapi;
+            rewrite ^/strapi/(.*) /$1 break;
+            proxy_pass http://strapi;
             access_log off;
         }
 
         location ^~ /uploads {
-            rewrite           ^/uploads/(.*) /uploads/$1 break;
-            proxy_pass   http://strapi;
+            rewrite ^/uploads/(.*) /uploads/$1 break;
+            proxy_pass http://strapi;
             access_log off;
         }
+    }
+
+    server {
+        server_name _;
+        listen 80;
     }
 }

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM strapi/base as base
+FROM strapi/base:14-alpine as base
 ARG APP_TINY_MCE_KEY
 ENV APP_TINY_MCE_KEY=${APP_TINY_MCE_KEY}
 WORKDIR /app


### PR DESCRIPTION
since we have a workaround for HTTPS reverse proxy, now our reverse proxy app will handle the HTTPS by it self so please prepare the system before the merge
- [x] remove workaround reverse proxy
- [x] allow traffic to pass through the app-reverse proxy
- [x] AAAA ns name can challenge to get cert form let encrypt.
